### PR TITLE
Add consistent backup functionality to PowerShell installer

### DIFF
--- a/fix-json-config.ps1
+++ b/fix-json-config.ps1
@@ -17,11 +17,14 @@ if (-not (Test-Path $RepoDir)) {
     $RepoDir = Read-Host "Please enter the full path to your ClaudeComputerCommander-Unlocked installation"
 }
 
-# Create a backup of the existing config
+# Create a backup of the existing config with date/time stamp
+$BackupCreated = $false
 if (Test-Path $ClaudeConfigPath) {
-    $BackupPath = $ClaudeConfigPath -replace ".json$", ".backup.json"
+    $Timestamp = Get-Date -Format "yyyy-MM-dd-HH.mm"
+    $BackupPath = Join-Path (Split-Path $ClaudeConfigPath) "claude_desktop_config-bk-$Timestamp.json"
     Copy-Item -Path $ClaudeConfigPath -Destination $BackupPath -Force
     Write-Host "Created backup of current configuration at: $BackupPath" -ForegroundColor Green
+    $BackupCreated = $true
 }
 
 # Create the configuration JSON with the exactly correct format
@@ -45,6 +48,13 @@ Write-Host ""
 Write-Host "Successfully created a valid JSON configuration." -ForegroundColor Green
 Write-Host "Path: $ClaudeConfigPath" -ForegroundColor Cyan
 Write-Host ""
+
+if ($BackupCreated) {
+    Write-Host "A backup of your previous configuration was created at:"
+    Write-Host $BackupPath -ForegroundColor Cyan
+    Write-Host ""
+}
+
 Write-Host "Please restart Claude Desktop for changes to take effect."
 Write-Host "Press any key to exit..."
 $null = $Host.UI.RawUI.ReadKey("NoEcho,IncludeKeyDown")

--- a/simple-install.ps1
+++ b/simple-install.ps1
@@ -28,6 +28,16 @@ if (-not (Test-Path $ClaudeConfigDir)) {
 }
 $ClaudeConfig = Join-Path $ClaudeConfigDir "claude_desktop_config.json"
 
+# Check if config exists and create a backup with date/time stamp
+$BackupCreated = $false
+if (Test-Path $ClaudeConfig) {
+    $Timestamp = Get-Date -Format "yyyy-MM-dd-HH.mm"
+    $BackupFile = "$ClaudeConfigDir\claude_desktop_config-bk-$Timestamp.json"
+    Copy-Item -Path $ClaudeConfig -Destination $BackupFile -Force
+    Write-Host "Created backup of existing config at: $BackupFile" -ForegroundColor Green
+    $BackupCreated = $true
+}
+
 # Create Claude config file if it doesn't exist
 if (-not (Test-Path $ClaudeConfig)) {
     Write-Host "Creating Claude Desktop configuration file..."
@@ -242,6 +252,13 @@ Write-Host ""
 Write-Host "Claude Desktop has been configured to use this installation at:"
 Write-Host $ClaudeConfig -ForegroundColor Cyan
 Write-Host ""
+
+if ($BackupCreated) {
+    Write-Host "A backup of your previous configuration was created at:"
+    Write-Host $BackupFile -ForegroundColor Cyan
+    Write-Host ""
+}
+
 Write-Host "Please restart Claude Desktop to apply the changes."
 Write-Host "If Claude is already running, close it and start it again."
 Write-Host ""


### PR DESCRIPTION
## Problem
The PowerShell installer script and the JSON fix script don't create backups of the existing Claude configuration file before making changes to it. This can cause issues if something goes wrong during the installation process, as the original configuration would be lost.

## Fix
This PR adds consistent backup functionality with date/time stamping to both the PowerShell installer and the JSON configuration fix script:

1. In `simple-install.ps1`, we now:
   - Create a backup with a timestamp in format "yyyy-MM-dd-HH.mm" 
   - Store the backup path in a variable for later reference
   - Report the backup path to the user at the end of the installation
   - Use a flag to track if a backup was created

2. In `fix-json-config.ps1`, we similarly:
   - Replace the existing basic backup with a timestamped version
   - Properly track and report the backup location to the user
   - Use consistent formatting and messaging with the main installer

## Benefits
- Safeguards user's existing configuration files
- Creates properly named backups that make it easy to identify when they were created
- Uses consistent backup format across all tools
- Clearly informs the user where their backup is stored

No functional changes to the core installation process were made - this is purely a safety enhancement.