### PR TITLE
Fix PowerShell JSON generation and add emergency repair tools

### DIFF
--- a/emergency-fix.bat
+++ b/emergency-fix.bat
@@ -1,0 +1,50 @@
+@echo off
+echo Claude Desktop Configuration Emergency Fix
+echo ========================================
+echo This script will fix JSON configuration errors.
+echo.
+
+:: Create a minimal working JSON configuration file
+echo Creating Emergency Fix...
+
+:: Set Claude config path
+set CLAUDE_DIR=%APPDATA%\Claude
+set CONFIG_FILE=%CLAUDE_DIR%\claude_desktop_config.json
+
+:: Create directory if it doesn't exist
+if not exist "%CLAUDE_DIR%" (
+    mkdir "%CLAUDE_DIR%" 2>nul
+    echo Created Claude directory at: %CLAUDE_DIR%
+)
+
+:: Create backup if file exists
+if exist "%CONFIG_FILE%" (
+    :: Get current date and time for backup filename
+    for /f "tokens=2 delims==" %%a in ('wmic OS Get localdatetime /value') do set "dt=%%a"
+    set "YYYY=%dt:~0,4%"
+    set "MM=%dt:~4,2%"
+    set "DD=%dt:~6,2%"
+    set "HH=%dt:~8,2%"
+    set "Min=%dt:~10,2%"
+    set "Sec=%dt:~12,2%"
+    set "BACKUP_FILE=%CLAUDE_DIR%\claude_desktop_config-backup-%YYYY%-%MM%-%DD%-%HH%.%Min%.json"
+    
+    copy "%CONFIG_FILE%" "%BACKUP_FILE%" >nul 2>&1
+    echo Backup created at: %BACKUP_FILE%
+)
+
+:: Create minimal valid JSON
+echo { > "%CONFIG_FILE%"
+echo   "mcpServers": {} >> "%CONFIG_FILE%"
+echo } >> "%CONFIG_FILE%"
+
+echo.
+echo Emergency fix applied!
+echo.
+echo The Claude Desktop configuration has been fixed at:
+echo %CONFIG_FILE%
+echo.
+echo Please restart Claude Desktop and then run the install script again.
+echo.
+echo Press any key to exit...
+pause >nul

--- a/emergency-fix.ps1
+++ b/emergency-fix.ps1
@@ -1,0 +1,69 @@
+# Emergency Fix for Claude Desktop Configuration
+# This is the simplest possible fix with no dependencies
+
+Write-Host "Claude Desktop Emergency Fix" -ForegroundColor Red
+Write-Host "===========================" -ForegroundColor Red
+Write-Host "This tool will fix the 'Unexpected token' error in claude_desktop_config.json"
+Write-Host ""
+
+# Find the Claude config directory and file
+$ClaudeConfigDir = Join-Path $env:APPDATA "Claude"
+$ClaudeConfigPath = Join-Path $ClaudeConfigDir "claude_desktop_config.json"
+
+# Create the config directory if it doesn't exist
+if (-not (Test-Path $ClaudeConfigDir)) {
+    try {
+        New-Item -ItemType Directory -Path $ClaudeConfigDir -Force | Out-Null
+        Write-Host "Created Claude configuration directory at: $ClaudeConfigDir" -ForegroundColor Green
+    } catch {
+        Write-Host "Error creating Claude directory: $_" -ForegroundColor Red
+        Write-Host "Please create the directory manually: $ClaudeConfigDir" -ForegroundColor Yellow
+    }
+}
+
+# Create a backup with timestamp
+$BackupCreated = $false
+if (Test-Path $ClaudeConfigPath) {
+    $CurrentDate = Get-Date -Format "yyyy-MM-dd-HH.mm.ss"
+    $BackupPath = Join-Path $ClaudeConfigDir "claude_desktop_config-backup-$CurrentDate.json"
+    try {
+        Copy-Item -Path $ClaudeConfigPath -Destination $BackupPath -Force
+        Write-Host "Created backup at: $BackupPath" -ForegroundColor Green
+        $BackupCreated = $true
+    } catch {
+        Write-Host "Warning: Could not create backup: $_" -ForegroundColor Yellow
+    }
+}
+
+# Create the minimal valid JSON configuration
+try {
+    # Use direct System.IO.File method to write UTF-8 without BOM
+    [System.IO.File]::WriteAllText($ClaudeConfigPath, '{"mcpServers":{}}', [System.Text.Encoding]::UTF8)
+    Write-Host "Successfully created minimal valid configuration!" -ForegroundColor Green
+    
+    # Verify the file exists and is readable
+    if (Test-Path $ClaudeConfigPath) {
+        $fileSize = (Get-Item $ClaudeConfigPath).Length
+        Write-Host "Verification: File exists and is $fileSize bytes." -ForegroundColor Green
+    } else {
+        Write-Host "Warning: File was written but cannot be found." -ForegroundColor Yellow
+    }
+} catch {
+    Write-Host "Error creating configuration file: $_" -ForegroundColor Red
+    Write-Host "Manual intervention required. Please create the file at: $ClaudeConfigPath" -ForegroundColor Yellow
+    Write-Host "with the following content: {`"mcpServers`":{}}" -ForegroundColor Yellow
+}
+
+Write-Host ""
+Write-Host "Fix completed. Please restart Claude Desktop." -ForegroundColor Cyan
+Write-Host ""
+if ($BackupCreated) {
+    Write-Host "A backup of your previous configuration was created at:"
+    Write-Host $BackupPath -ForegroundColor Cyan
+}
+Write-Host ""
+Write-Host "Note: This fix creates a minimal configuration with no Commander settings."
+Write-Host "After Claude starts successfully, run the proper installation script again."
+Write-Host ""
+Write-Host "Press any key to exit..."
+$null = $Host.UI.RawUI.ReadKey("NoEcho,IncludeKeyDown")

--- a/fix-json-config.ps1
+++ b/fix-json-config.ps1
@@ -7,7 +7,8 @@ Write-Host "This will create a valid JSON configuration file for Claude Desktop.
 Write-Host ""
 
 # Find the Claude config file
-$ClaudeConfigPath = Join-Path $env:APPDATA "Claude\claude_desktop_config.json"
+$ClaudeConfigDir = Join-Path $env:APPDATA "Claude"
+$ClaudeConfigPath = Join-Path $ClaudeConfigDir "claude_desktop_config.json"
 Write-Host "Using configuration at: $ClaudeConfigPath"
 
 # Get the ClaudeComputerCommander path
@@ -17,34 +18,89 @@ if (-not (Test-Path $RepoDir)) {
     $RepoDir = Read-Host "Please enter the full path to your ClaudeComputerCommander-Unlocked installation"
 }
 
-# Create a backup of the existing config
+# Create a backup of the existing config with date/time stamp
+$BackupCreated = $false
 if (Test-Path $ClaudeConfigPath) {
-    $BackupPath = $ClaudeConfigPath -replace ".json$", ".backup.json"
-    Copy-Item -Path $ClaudeConfigPath -Destination $BackupPath -Force
-    Write-Host "Created backup of current configuration at: $BackupPath" -ForegroundColor Green
+    $CurrentDate = Get-Date -Format "yyyy-MM-dd-HH.mm"
+    $BackupPath = Join-Path $ClaudeConfigDir "claude_desktop_config-backup-$CurrentDate.json"
+    try {
+        Copy-Item -Path $ClaudeConfigPath -Destination $BackupPath -Force
+        Write-Host "Created backup of current configuration at: $BackupPath" -ForegroundColor Green
+        $BackupCreated = $true
+    }
+    catch {
+        Write-Host "Warning: Failed to create backup file. Will proceed anyway." -ForegroundColor Yellow
+        Write-Host "Error: $_" -ForegroundColor Red
+    }
 }
 
-# Create the configuration JSON with the exactly correct format
+# Prepare the path to the index.js file with proper escaping
+$IndexPath = Join-Path $RepoDir "dist\index.js"
+$IndexPath = $IndexPath.Replace('\', '\\')
+
+# Create the configuration JSON with exact structure
 $correctJson = @"
 {
   "mcpServers": {
     "desktopCommander": {
       "command": "node",
       "args": [
-        "$($RepoDir.Replace('\', '\\'))\\dist\\index.js"
+        "$IndexPath"
       ]
     }
   }
 }
 "@
 
-# Write the configuration to file
-$correctJson | Out-File -FilePath $ClaudeConfigPath -Encoding utf8 -NoNewline
+# Write the configuration file using System.IO.File to ensure proper encoding without BOM
+try {
+    # If the directory doesn't exist, create it
+    if (-not (Test-Path $ClaudeConfigDir)) {
+        New-Item -ItemType Directory -Path $ClaudeConfigDir -Force | Out-Null
+        Write-Host "Created Claude Desktop configuration directory." -ForegroundColor Green
+    }
+    
+    # Write the file with UTF-8 encoding without BOM
+    [System.IO.File]::WriteAllText($ClaudeConfigPath, $correctJson, [System.Text.Encoding]::UTF8)
+    Write-Host "Configuration file created successfully." -ForegroundColor Green
+    
+    # Validate the JSON
+    try {
+        $testJson = Get-Content -Path $ClaudeConfigPath -Raw | ConvertFrom-Json
+        Write-Host "JSON validation successful!" -ForegroundColor Green
+    } catch {
+        Write-Host "Warning: JSON validation failed. Creating minimal configuration..." -ForegroundColor Yellow
+        Write-Host "Error: $_" -ForegroundColor Red
+        
+        # Create an ultra-minimal configuration as a fallback
+        [System.IO.File]::WriteAllText($ClaudeConfigPath, '{"mcpServers":{}}', [System.Text.Encoding]::UTF8)
+        Write-Host "Created minimal fallback configuration." -ForegroundColor Yellow
+    }
+} catch {
+    Write-Host "Error writing configuration file: $_" -ForegroundColor Red
+    Write-Host "Attempting to create minimal configuration..." -ForegroundColor Yellow
+    
+    try {
+        [System.IO.File]::WriteAllText($ClaudeConfigPath, '{"mcpServers":{}}', [System.Text.Encoding]::UTF8)
+        Write-Host "Created minimal fallback configuration." -ForegroundColor Yellow
+    } catch {
+        Write-Host "Critical error: Could not write configuration file." -ForegroundColor Red
+    }
+}
 
 Write-Host ""
-Write-Host "Successfully created a valid JSON configuration." -ForegroundColor Green
+Write-Host "JSON configuration fix complete." -ForegroundColor Green
 Write-Host "Path: $ClaudeConfigPath" -ForegroundColor Cyan
 Write-Host ""
+
+if ($BackupCreated) {
+    Write-Host "A backup of your previous configuration was created at:"
+    Write-Host $BackupPath -ForegroundColor Cyan
+    Write-Host ""
+}
+
 Write-Host "Please restart Claude Desktop for changes to take effect."
+Write-Host "If Claude is already running, close it and start it again."
+Write-Host ""
 Write-Host "Press any key to exit..."
 $null = $Host.UI.RawUI.ReadKey("NoEcho,IncludeKeyDown")


### PR DESCRIPTION
## Problem
The PowerShell installer scripts are experiencing issues with properly creating backups of the configuration file and generating valid JSON files. This is causing errors when opening Claude Desktop with a message about "Unexpected token ',', 'mcps'... is not valid JSON".

## Fix
This PR provides robust fixes for the JSON format issues and backup creation:

### 1. PowerShell Installer Improvements
- Now uses `System.IO.File.WriteAllText` with explicit UTF-8 encoding (without BOM) for config creation
- Added proper try/catch blocks for more reliable error handling
- Fixed backup creation with consistent timestamping format
- Added validation of the JSON after creation
- Adds fallback mechanism to create minimal JSON if detailed configuration fails

### 2. JSON Fix Script Enhancements
- Same improvements for backup creation and error handling
- Improved messaging about backup location
- Validates JSON format before finishing

### 3. Added Emergency Fix Tools
- New `emergency-fix.ps1` PowerShell script using the most direct method to create a valid config
- New `emergency-fix.bat` batch script for systems where PowerShell execution may be restricted
- Both scripts create timestamped backups of existing config files before changes
- Both generate the simplest valid JSON possible to get Claude working

## Benefits
- Fixes the "Unexpected token" JSON error
- Creates reliable backups with timestamps
- Provides multiple fallback mechanisms
- Available in both PowerShell and batch format for maximum compatibility
- Verifies JSON validity after creation

These fixes ensure that users can recover from broken config files and continue to use Claude Desktop with Commander functionality.