### PR TITLE
Fix path issues for Windows systems

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -6,14 +6,30 @@ import { commandManager } from './command-manager.js';
 import { join, dirname } from 'path';
 import { fileURLToPath } from 'url';
 
+// Determine the directory where this script is located
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 
+// Log process info for debugging
+function logProcessInfo() {
+  console.log({
+    cwd: process.cwd(),
+    scriptDir: __dirname,
+    nodeVersion: process.version,
+    platform: process.platform
+  });
+}
+
 async function runSetup() {
-  const setupScript = join(__dirname, 'setup-claude-server.js');
-  const { default: setupModule } = await import(setupScript);
-  if (typeof setupModule === 'function') {
-    await setupModule();
+  try {
+    const setupScript = join(__dirname, 'setup-claude-server.js');
+    const { default: setupModule } = await import(setupScript);
+    if (typeof setupModule === 'function') {
+      await setupModule();
+    }
+  } catch (error) {
+    console.error('Setup error:', error);
+    process.exit(1);
   }
 }
 
@@ -25,15 +41,20 @@ async function runServer() {
       return;
     }
     
+    // For debugging - uncomment if needed
+    // logProcessInfo();
+    
     // Handle uncaught exceptions
     process.on('uncaughtException', async (error) => {
       const errorMessage = error instanceof Error ? error.message : String(error);
+      console.error(`Uncaught exception: ${errorMessage}`);
       process.exit(1);
     });
 
     // Handle unhandled rejections
     process.on('unhandledRejection', async (reason) => {
       const errorMessage = reason instanceof Error ? reason.message : String(reason);
+      console.error(`Unhandled rejection: ${errorMessage}`);
       process.exit(1);
     });
 


### PR DESCRIPTION
This PR fixes the path resolution issues on Windows systems that can cause Claude Desktop to fail when loading the Computer Commander MCP server.

Changes include:
1. Improved path resolution in config.ts to handle various installation locations
2. Added better error handling for missing configuration files
3. Added detection of multiple potential Claude installation locations
4. Fixed path handling in command-manager.ts to work with both relative and absolute paths
5. Improved error reporting in index.ts

This should resolve the issue where Claude Desktop is looking for the index.js file in an incorrect location.
